### PR TITLE
Add tasks for rebooting and removing the provision user

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,8 @@ Example Playbook
            become: true
            vars:
              root_password: "hunter2"
+      post_tasks:
+         - name: Reboot and remove the provision user
+           ansible.builtin.import_role:
+             name: wandansible.provision
+             tasks_from: reboot

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,6 @@ provision_full_upgrade: true
 
 provision_user_public_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP2j7zQRR6VhATko1eFexV/iCEQFNyLYpP8gn3fg0Bxn ansible@wand"
 provision_user_private_key_file: "ssh/ansible_ed25519"
+
+provision_reboot: true
+provision_reboot_timeout: 600

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -54,6 +54,16 @@ argument_specs:
         type: bool
         default: true
 
+      provision_reboot:
+        description: If true, ask user whether to reboot the host
+        type: bool
+        default: true
+
+      provision_reboot_timeout:
+        description: Time in seconds to wait for the host to reboot
+        type: int
+        default: 600
+
       root_password:
         description: Password for the root user
         type: str

--- a/tasks/reboot.yml
+++ b/tasks/reboot.yml
@@ -1,0 +1,26 @@
+---
+- block:
+    - name: Reboot before removing provision user
+      ansible.builtin.pause:
+        prompt: >-
+          The machine has finished being built,
+          a reboot may be necessary to successfully remove the provision user.
+          Do you want to reboot the machine? (y/n)
+      register: _reboot_check_resonse
+
+    - name: Reboot machine
+      ansible.builtin.reboot:
+        reboot_timeout: "{{ provision_reboot_timeout }}"
+      when:
+        - "'user_input' in _reboot_check_resonse"
+        - >-
+            _reboot_check_resonse.user_input | lower == 'y' or
+            _reboot_check_resonse.user_input | lower == 'yes'
+  when: provision_reboot | bool
+
+- name: Remove provision user
+  ansible.builtin.user:
+    name: "{{ provision_user_username }}"
+    state: absent
+    remove: true
+  when: not provision_user_keep | bool


### PR DESCRIPTION
Add useful reboot tasks that can be added at the end of a playbook.